### PR TITLE
Support for save/load on hash internal state to allow resumable hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,9 +321,9 @@ fn.update("world!");
 console.log(fn.digest()); // Prints 6cd3556deb0da54bca060b4c39479839
 ```
 
-Note that both the saving and loading processes **must** be running the same build of hash-wasm, there is no portability
-between different versions or different builds. Loading incompatible states could cause exceptions, infinite loops, or 
-silently-wrong answers.
+Note that both the saving and loading processes must be running compatible versions of the hash function (i.e. the
+hash function hasn't changed between the versions of hash-wasm used in the saving and loading processes). If the 
+saved state is incompatible, `load()` will throw an exception.
 
 The saved state can contain information about the input, including plaintext input bytes, so from a security perspective 
 it must be treated with the same care as the input data itself.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Features
 - Works in Web Workers
 - Zero dependencies
 - Supports concurrent hash calculations with multiple states
+- Supports saving and loading the state of the hash to support segmented hashing and rewinding 
 - [Unit tests](https://github.com/Daninet/hash-wasm/tree/master/test) for all algorithms
 - 100% open source & transparent [build process](https://github.com/Daninet/hash-wasm/actions)
 - Easy to use, Promise-based API
@@ -293,6 +294,39 @@ te.encode('\u00fc'.normalize('NFKC')); // Uint8Array(2) [195, 188]
 ```
 
 You can read more about this issue here: https://en.wikipedia.org/wiki/Unicode_equivalence
+
+### Resumable hashing
+
+You can save the current state of the hash to a Uint8Array (after `.init()` has been called, but before `.digest()`) 
+using the `.save()` function. This state may be written to disk or stored elsewhere in memory. You can then use the 
+`.load(state)` function to reload that state into a new instance of the hash, or back into the same instance.
+
+This allows you to span the work of hashing a file across multiple processes (e.g. in environments with limited 
+execution times like AWS Lambda, where large jobs need to be split across multiple invocations), or rewind the hash 
+to an earlier point in the stream. For example, the first process could:
+
+```js
+const fn = createMD5();
+fn.init();
+fn.update("Hello, ");
+const state = fn.save(); // Save this state to a file
+```
+
+Then a second process can load that state and resume hashing:
+
+```js
+const fn = createMD5();
+fn.load(state);
+fn.update("world!");
+console.log(fn.digest()); // Prints 6cd3556deb0da54bca060b4c39479839
+```
+
+Note that both the saving and loading processes **must** be running the same build of hash-wasm, there is no portability
+between different versions or different builds. Loading incompatible states could cause exceptions, infinite loops, or 
+silently-wrong answers.
+
+The saved state can contain information about the input, including plaintext input bytes, so from a security perspective 
+it must be treated with the same care as the input data itself.
 
 <br/>
 

--- a/lib/blake2b.ts
+++ b/lib/blake2b.ts
@@ -112,6 +112,8 @@ export function createBLAKE2b(
         },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 128,
       digestSize: outputSize,
     };

--- a/lib/blake2s.ts
+++ b/lib/blake2s.ts
@@ -112,6 +112,8 @@ export function createBLAKE2s(
         },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: outputSize,
     };

--- a/lib/blake3.ts
+++ b/lib/blake3.ts
@@ -109,6 +109,8 @@ export function createBLAKE3(
         },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType, digestParam) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: outputSize,
     };

--- a/lib/crc32.ts
+++ b/lib/crc32.ts
@@ -39,6 +39,8 @@ export function createCRC32(): Promise<IHasher> {
       init: () => { wasm.init(); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 4,
       digestSize: 4,
     };

--- a/lib/hmac.ts
+++ b/lib/hmac.ts
@@ -53,6 +53,12 @@ function calculateHmac(hasher: IHasher, key: IDataType): IHasher {
       hasher.update(uintArr);
       return hasher.digest(outputType);
     }) as any,
+    save: () => {
+      throw new Error('save() not supported');
+    },
+    load: () => {
+      throw new Error('load() not supported');
+    },
 
     blockSize: hasher.blockSize,
     digestSize: hasher.digestSize,

--- a/lib/keccak.ts
+++ b/lib/keccak.ts
@@ -64,6 +64,8 @@ export function createKeccak(bits: IValidBits = 512): Promise<IHasher> {
       init: () => { wasm.init(bits); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType, 0x01) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 200 - 2 * outputSize,
       digestSize: outputSize,
     };

--- a/lib/md4.ts
+++ b/lib/md4.ts
@@ -39,6 +39,8 @@ export function createMD4(): Promise<IHasher> {
       init: () => { wasm.init(); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: 16,
     };

--- a/lib/md5.ts
+++ b/lib/md5.ts
@@ -39,6 +39,8 @@ export function createMD5(): Promise<IHasher> {
       init: () => { wasm.init(); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: 16,
     };

--- a/lib/ripemd160.ts
+++ b/lib/ripemd160.ts
@@ -39,6 +39,8 @@ export function createRIPEMD160(): Promise<IHasher> {
       init: () => { wasm.init(); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: 20,
     };

--- a/lib/sha1.ts
+++ b/lib/sha1.ts
@@ -39,6 +39,8 @@ export function createSHA1(): Promise<IHasher> {
       init: () => { wasm.init(); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: 20,
     };

--- a/lib/sha224.ts
+++ b/lib/sha224.ts
@@ -39,6 +39,8 @@ export function createSHA224(): Promise<IHasher> {
       init: () => { wasm.init(224); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: 28,
     };

--- a/lib/sha256.ts
+++ b/lib/sha256.ts
@@ -39,6 +39,8 @@ export function createSHA256(): Promise<IHasher> {
       init: () => { wasm.init(256); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: 32,
     };

--- a/lib/sha3.ts
+++ b/lib/sha3.ts
@@ -63,6 +63,8 @@ export function createSHA3(bits: IValidBits = 512): Promise<IHasher> {
       init: () => { wasm.init(bits); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType, 0x06) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 200 - 2 * outputSize,
       digestSize: outputSize,
     };

--- a/lib/sha384.ts
+++ b/lib/sha384.ts
@@ -39,6 +39,8 @@ export function createSHA384(): Promise<IHasher> {
       init: () => { wasm.init(384); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 128,
       digestSize: 48,
     };

--- a/lib/sha512.ts
+++ b/lib/sha512.ts
@@ -39,6 +39,8 @@ export function createSHA512(): Promise<IHasher> {
       init: () => { wasm.init(512); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 128,
       digestSize: 64,
     };

--- a/lib/sm3.ts
+++ b/lib/sm3.ts
@@ -39,6 +39,8 @@ export function createSM3(): Promise<IHasher> {
       init: () => { wasm.init(); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: 32,
     };

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -36,6 +36,19 @@ export function writeHexToUInt8(buf: Uint8Array, str: string) {
   }
 }
 
+export function hexStringEqualsUInt8(str: string, buf: Uint8Array): boolean {
+  if (str.length !== buf.length * 2) {
+    return false;
+  }
+  for (let i = 0; i < buf.length; i++) {
+    const strIndex = i << 1;
+    if (buf[i] !== hexCharCodesToInt(str.charCodeAt(strIndex), str.charCodeAt(strIndex + 1))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 const alpha = 'a'.charCodeAt(0) - 10;
 const digit = '0'.charCodeAt(0);
 export function getDigestHex(tmpBuffer: Uint8Array, input: Uint8Array, hashLength: number): string {

--- a/lib/whirlpool.ts
+++ b/lib/whirlpool.ts
@@ -39,6 +39,8 @@ export function createWhirlpool(): Promise<IHasher> {
       init: () => { wasm.init(); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 64,
       digestSize: 64,
     };

--- a/lib/xxhash32.ts
+++ b/lib/xxhash32.ts
@@ -58,6 +58,8 @@ export function createXXHash32(seed = 0): Promise<IHasher> {
       init: () => { wasm.init(seed); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 16,
       digestSize: 4,
     };

--- a/lib/xxhash64.ts
+++ b/lib/xxhash64.ts
@@ -91,6 +91,8 @@ export function createXXHash64(seedLow = 0, seedHigh = 0): Promise<IHasher> {
       },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
       blockSize: 32,
       digestSize: 8,
     };

--- a/scripts/make_json.js
+++ b/scripts/make_json.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const dir = path.resolve(__dirname, '..', 'wasm');
 const files = fs.readdirSync(dir).filter((file) => file.endsWith('.wasm'));
@@ -8,6 +9,9 @@ files.forEach((file) => {
   const data = fs.readFileSync(path.join(dir, file));
   const base64Data = data.toString('base64');
   const parsedName = path.parse(file);
-  const json = JSON.stringify({ name: parsedName.name, data: base64Data });
+  const sha1 = crypto.createHash('sha1');
+  sha1.update(data);
+  const hash = sha1.digest('hex').substring(0, 8);
+  const json = JSON.stringify({ name: parsedName.name, data: base64Data, hash });
   fs.writeFileSync(path.join(dir, `${file}.json`), json);
 });

--- a/src/blake2b.c
+++ b/src/blake2b.c
@@ -283,6 +283,14 @@ void Hash_Update(uint32_t size) {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(S); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) S;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length, uint32_t initParam) {
   Hash_Init(initParam);
   Hash_Update(length);

--- a/src/blake2s.c
+++ b/src/blake2s.c
@@ -269,6 +269,14 @@ void Hash_Update(uint32_t size) {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(S); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) S;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length, uint32_t initParam) {
   Hash_Init(initParam);
   Hash_Update(length);

--- a/src/blake3.c
+++ b/src/blake3.c
@@ -852,6 +852,14 @@ void Hash_Final(uint32_t digestBytes) {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(hasher); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) &hasher;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length, uint32_t initParam, uint32_t digestBytes) {
   Hash_Init(initParam);
   Hash_Update(length);

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -84,6 +84,14 @@ void Hash_Final() {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(previousCrc32); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) &previousCrc32;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length) {
   Hash_Init();
   Hash_Update(length);

--- a/src/md4.c
+++ b/src/md4.c
@@ -275,6 +275,14 @@ void Hash_Final() {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(*ctx); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) ctx;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length) {
   Hash_Init();
   Hash_Update(length);

--- a/src/md5.c
+++ b/src/md5.c
@@ -296,6 +296,14 @@ void Hash_Final() {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(*ctx); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) ctx;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length) {
   Hash_Init();
   Hash_Update(length);

--- a/src/ripemd160.c
+++ b/src/ripemd160.c
@@ -293,6 +293,14 @@ void Hash_Final() {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(*ctx); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) ctx;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length) {
   Hash_Init();
   Hash_Update(length);

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -177,6 +177,14 @@ void Hash_Final() {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(*context); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) context;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length) {
   Hash_Init();
   Hash_Update(length);

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -280,6 +280,14 @@ void Hash_Final() {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(*ctx); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) ctx;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length, uint32_t initParam) {
   Hash_Init(initParam);
   Hash_Update(length);

--- a/src/sha3.c
+++ b/src/sha3.c
@@ -317,6 +317,14 @@ void Hash_Final(uint8_t padding) {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(*ctx); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) ctx;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length, uint32_t initParam, uint8_t finalParam) {
   Hash_Init(initParam);
   Hash_Update(length);

--- a/src/sha512.c
+++ b/src/sha512.c
@@ -293,6 +293,14 @@ void Hash_Final() {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(*ctx); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) ctx;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length, uint32_t initParam) {
   Hash_Init(initParam);
   Hash_Update(length);

--- a/src/sm3.c
+++ b/src/sm3.c
@@ -216,6 +216,14 @@ void Hash_Final() {
 }
 
 WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(ctx); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) &ctx;
+}
+
+WASM_EXPORT
 void Hash_Calculate(uint32_t length) {
   Hash_Init();
   Hash_Update(length);

--- a/src/xxhash32.c
+++ b/src/xxhash32.c
@@ -22,10 +22,14 @@ static const uint32_t Prime5 = 374761393U;
 static const uint32_t MaxBufferSize = 15 + 1;
 
 // internal state and temporary buffer
-uint32_t state[4];  // state[2] == seed if totalLength < MaxBufferSize
-unsigned char buffer[MaxBufferSize];
-unsigned int bufferSize;
-uint64_t totalLength;
+struct XXHash32_CTX {
+	uint32_t state[4];  // state[2] == seed if totalLength < MaxBufferSize
+	unsigned char buffer[MaxBufferSize];
+	unsigned int bufferSize;
+	uint64_t totalLength;
+};
+
+static struct XXHash32_CTX sctx;
 
 // rotate bits, should compile to a single CPU instruction (ROL)
 static inline uint32_t rotateLeft(uint32_t x, unsigned char bits) {
@@ -50,12 +54,12 @@ static inline void process(
  * **/
 WASM_EXPORT
 void Hash_Init(uint32_t seed) {
-  state[0] = seed + Prime1 + Prime2;
-  state[1] = seed + Prime2;
-  state[2] = seed;
-  state[3] = seed - Prime1;
-  bufferSize = 0;
-  totalLength = 0;
+  sctx.state[0] = seed + Prime1 + Prime2;
+  sctx.state[1] = seed + Prime2;
+  sctx.state[2] = seed;
+  sctx.state[3] = seed - Prime1;
+  sctx.bufferSize = 0;
+  sctx.totalLength = 0;
 }
 
 // add a chunk of bytes
@@ -69,15 +73,15 @@ void Hash_Update(uint32_t length) {
   // no data ?
   if (!input || length == 0) return;
 
-  totalLength += length;
+  sctx.totalLength += length;
   // byte-wise access
   const unsigned char* data = (const unsigned char*)input;
 
   // unprocessed old data plus new data still fit in temporary buffer ?
-  if (bufferSize + length < MaxBufferSize) {
+  if (sctx.bufferSize + length < MaxBufferSize) {
     // just add new data
     while (length-- > 0) {
-      buffer[bufferSize++] = *data++;
+      sctx.buffer[sctx.bufferSize++] = *data++;
     }
     return;
   }
@@ -87,18 +91,18 @@ void Hash_Update(uint32_t length) {
   const unsigned char* stopBlock = stop - MaxBufferSize;
 
   // some data left from previous update ?
-  if (bufferSize > 0) {
+  if (sctx.bufferSize > 0) {
     // make sure temporary buffer is full (16 bytes)
-    while (bufferSize < MaxBufferSize) {
-      buffer[bufferSize++] = *data++;
+    while (sctx.bufferSize < MaxBufferSize) {
+      sctx.buffer[sctx.bufferSize++] = *data++;
     }
 
     // process these 16 bytes (4x4)
-    process(buffer, &state[0], &state[1], &state[2], &state[3]);
+    process(sctx.buffer, &sctx.state[0], &sctx.state[1], &sctx.state[2], &sctx.state[3]);
   }
 
   // copying state to local variables helps optimizer A LOT
-  uint32_t s0 = state[0], s1 = state[1], s2 = state[2], s3 = state[3];
+  uint32_t s0 = sctx.state[0], s1 = sctx.state[1], s2 = sctx.state[2], s3 = sctx.state[3];
   // 16 bytes at once
   while (data <= stopBlock) {
     // local variables s0..s3 instead of state[0]..state[3] are much faster
@@ -106,15 +110,15 @@ void Hash_Update(uint32_t length) {
     data += 16;
   }
   // copy back
-  state[0] = s0;
-  state[1] = s1;
-  state[2] = s2;
-  state[3] = s3;
+  sctx.state[0] = s0;
+  sctx.state[1] = s1;
+  sctx.state[2] = s2;
+  sctx.state[3] = s3;
 
   // copy remainder to temporary buffer
-  bufferSize = stop - data;
-  for (unsigned int i = 0; i < bufferSize; i++) {
-    buffer[i] = data[i];
+  sctx.bufferSize = stop - data;
+  for (unsigned int i = 0; i < sctx.bufferSize; i++) {
+    sctx.buffer[i] = data[i];
   }
 }
 
@@ -122,24 +126,24 @@ void Hash_Update(uint32_t length) {
 /** @return 32 bit XXHash **/
 WASM_EXPORT
 void Hash_Final() {
-  uint32_t result = (uint32_t)totalLength;
+  uint32_t result = (uint32_t)sctx.totalLength;
 
   // fold 128 bit state into one single 32 bit value
-  if (totalLength >= MaxBufferSize) {
-    result += rotateLeft(state[0],  1) +
-              rotateLeft(state[1],  7) +
-              rotateLeft(state[2], 12) +
-              rotateLeft(state[3], 18);
+  if (sctx.totalLength >= MaxBufferSize) {
+    result += rotateLeft(sctx.state[0],  1) +
+              rotateLeft(sctx.state[1],  7) +
+              rotateLeft(sctx.state[2], 12) +
+              rotateLeft(sctx.state[3], 18);
   } else {
     // internal state wasn't set in add(), therefore original seed is still
     // stored in state2
-    result += state[2] + Prime5;
+    result += sctx.state[2] + Prime5;
   }
 
   // process remaining bytes in temporary buffer
-  const unsigned char* data = buffer;
+  const unsigned char* data = sctx.buffer;
   // point beyond last byte
-  const unsigned char* stop = data + bufferSize;
+  const unsigned char* stop = data + sctx.bufferSize;
 
   // at least 4 bytes left ? => eat 4 bytes per step
   for (; data + 4 <= stop; data += 4) {
@@ -162,6 +166,14 @@ void Hash_Final() {
   main_buffer[1] = (result & 0x00ff0000) >> 16;
   main_buffer[2] = (result & 0x0000ff00) >> 8;
   main_buffer[3] = result & 0x000000ff;
+}
+
+WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(sctx); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) &sctx;
 }
 
 WASM_EXPORT

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -3,11 +3,10 @@
 import * as api from '../lib';
 import { IHasher } from '../lib/WASMInterface';
 
-test('IHasherApi', async () => {
-  const keys = Object.keys(api).filter((key) => key.startsWith('create'));
-  expect(keys.length).toBe(19);
+async function createAllFunctions(includeHMAC) : Promise<IHasher[]> {
+  const keys = Object.keys(api).filter((key) => key.startsWith('create') && (includeHMAC || key !== 'createHMAC'));
 
-  const functions: IHasher[] = await Promise.all(
+  return Promise.all(
     keys.map(
       (key) => {
         switch (key) {
@@ -19,6 +18,11 @@ test('IHasherApi', async () => {
       },
     ),
   );
+}
+
+test('IHasherApi', async () => {
+  const functions: IHasher[] = await createAllFunctions(true);
+  expect(functions.length).toBe(19);
 
   // eslint-disable-next-line no-restricted-syntax
   for (const fn of functions) {
@@ -55,4 +59,47 @@ test('IHasherApi', async () => {
     expect(() => fn.digest()).toThrow();
     expect(() => fn.update('a')).toThrow();
   }
+});
+
+test('saveAndLoad', async () => {
+  const aHash: string[] = (await createAllFunctions(false)).map((fn) => { fn.init(); fn.update('a'); return fn.digest(); });
+  const abcHash: string[] = (await createAllFunctions(false)).map((fn) => { fn.init(); fn.update('abc'); return fn.digest(); });
+
+  const functions: IHasher[] = await createAllFunctions(false);
+
+  expect(functions.length).toBe(18);
+
+  functions.forEach((fn, index) => {
+    fn.init();
+    fn.load(fn.save());
+    fn.update('a');
+    const saved = fn.save();
+    fn.update('bc');
+    expect(fn.digest()).toBe(abcHash[index]);
+    fn.load(saved);
+    expect(fn.digest()).toBe(aHash[index]);
+    fn.load(saved);
+    fn.update('bc');
+    expect(fn.digest()).toBe(abcHash[index]);
+  });
+});
+
+test('loadInsteadOfInit', async () => {
+  // Verify that load() can be used instead of a call to init() and still give the same results
+  // This checks that e.g. crc32's init_lut() gets called even if we don't call init() ourselves
+  const helloWorldHashes = (await createAllFunctions(false)).map((fn) => {
+    fn.init();
+    fn.update('Hello world');
+    return fn.digest();
+  });
+  expect(helloWorldHashes.length).toBe(18);
+  const savedHasherStates = (await createAllFunctions(false)).map((fn) => {
+    fn.update('Hello ');
+    return fn.save();
+  });
+  (await createAllFunctions(false)).forEach((fn, index) => {
+    fn.load(savedHasherStates[index]);
+    fn.update('world');
+    expect(fn.digest()).toBe(helloWorldHashes[index]);
+  });
 });


### PR DESCRIPTION
In my project I'm hashing some very large files using AWS Lambda, which has a fixed maximum execution time. So partway through the file when I run out of execution time, I need to be able to save the state of the hash to disk, start a new Lambda, and resume that state in the new Lambda to continue hashing the file.

So far I have implemented this just for SHA1/CRC32, which are the hashes I'll be using.

Is this a concept that you're interested in merging? If so I could add support for more/all hashes.