### PR TITLE
Add Adler-32 hash function

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -34,3 +34,4 @@ Special thank you to the authors of original C algorithms:
 - Project Nayuki
 - ARM Limited
 - Yanbo Li dreamfly281@gmail.com, goldboar@163.comYanbo Li
+- Mark Adler

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Supported algorithms
 
 | Name                                           | Bundle size (gzipped) |
 |------------------------------------------------|-----------------------|
+| Adler-32                                       | 3 kB                  |
 | Argon2: Argon2d, Argon2i, Argon2id (v1.3)      | 11 kB                 |
 | bcrypt                                         | 11 kB                 |
 | BLAKE2b                                        | 6 kB                  |
@@ -418,6 +419,7 @@ API
 type IDataType = string | Buffer | Uint8Array | Uint16Array | Uint32Array;
 
 // all functions return hash in hex format
+adler32(data: IDataType): Promise<string>
 blake2b(data: IDataType, bits?: number, key?: IDataType): Promise<string> // default is 512 bits
 blake2s(data: IDataType, bits?: number, key?: IDataType): Promise<string> // default is 256 bits
 blake3(data: IDataType, bits?: number, key?: IDataType): Promise<string> // default is 256 bits
@@ -447,6 +449,7 @@ interface IHasher {
   digestSize: number; // in bytes
 }
 
+createAdler32(): Promise<IHasher>
 createBLAKE2b(bits?: number, key?: IDataType): Promise<IHasher> // default is 512 bits
 createBLAKE2s(bits?: number, key?: IDataType): Promise<IHasher> // default is 256 bits
 createBLAKE3(bits?: number, key?: IDataType): Promise<IHasher> // default is 256 bits

--- a/lib/adler32.ts
+++ b/lib/adler32.ts
@@ -1,0 +1,51 @@
+import { WASMInterface, IWASMInterface, IHasher } from './WASMInterface';
+import Mutex from './mutex';
+import wasmJson from '../wasm/adler32.wasm.json';
+import lockedCreate from './lockedCreate';
+import { IDataType } from './util';
+
+const mutex = new Mutex();
+let wasmCache: IWASMInterface = null;
+
+/**
+ * Calculates Adler-32 hash. The resulting 32-bit hash is stored in
+ * network byte order (big-endian).
+ *
+ * @param data Input data (string, Buffer or TypedArray)
+ * @returns Computed hash as a hexadecimal string
+ */
+export function adler32(data: IDataType): Promise<string> {
+  if (wasmCache === null) {
+    return lockedCreate(mutex, wasmJson, 4)
+      .then((wasm) => {
+        wasmCache = wasm;
+        return wasmCache.calculate(data);
+      });
+  }
+
+  try {
+    const hash = wasmCache.calculate(data);
+    return Promise.resolve(hash);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}
+
+/**
+ * Creates a new Adler-32 hash instance
+ */
+export function createAdler32(): Promise<IHasher> {
+  return WASMInterface(wasmJson, 4).then((wasm) => {
+    wasm.init();
+    const obj: IHasher = {
+      init: () => { wasm.init(); return obj; },
+      update: (data) => { wasm.update(data); return obj; },
+      digest: (outputType) => wasm.digest(outputType) as any,
+      save: () => wasm.save(),
+      load: (data) => { wasm.load(data); return obj; },
+      blockSize: 4,
+      digestSize: 4,
+    };
+    return obj;
+  });
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './adler32';
 export * from './argon2';
 export * from './blake2b';
 export * from './blake2s';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hash-wasm",
   "version": "4.6.0",
-  "description": "Lightning fast hash functions for browsers and Node.js using hand-tuned WebAssembly binaries (MD4, MD5, SHA-1, SHA-2, SHA-3, Keccak, BLAKE2, BLAKE3, PBKDF2, Argon2, bcrypt, scrypt, CRC32, RIPEMD-160, HMAC, xxHash, SM3, Whirlpool)",
+  "description": "Lightning fast hash functions for browsers and Node.js using hand-tuned WebAssembly binaries (MD4, MD5, SHA-1, SHA-2, SHA-3, Keccak, BLAKE2, BLAKE3, PBKDF2, Argon2, bcrypt, scrypt, Adler-32, CRC32, RIPEMD-160, HMAC, xxHash, SM3, Whirlpool)",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
   "types": "dist/lib/index.d.ts",
@@ -23,6 +23,7 @@
     "wasm",
     "webassembly",
     "md5",
+    "adler-32",
     "crc32",
     "sha-1",
     "sha-2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import { terser } from 'rollup-plugin-terser';
 import license from 'rollup-plugin-license';
 
 const ALGORITHMS = [
-  'argon2', 'bcrypt', 'blake2b', 'blake2s', 'blake3', 'crc32', 'hmac', 'keccak', 'md4', 'md5',
+  'adler32', 'argon2', 'bcrypt', 'blake2b', 'blake2s', 'blake3', 'crc32', 'hmac', 'keccak', 'md4', 'md5',
   'pbkdf2', 'ripemd160', 'scrypt', 'sha1', 'sha3', 'sha224', 'sha256', 'sha384', 'sha512',
   'sm3', 'whirlpool', 'xxhash32', 'xxhash64',
 ];

--- a/scripts/Makefile-clang
+++ b/scripts/Makefile-clang
@@ -5,6 +5,7 @@ LDFLAGS=-Wl,--strip-all -Wl,--initial-memory=131072 -Wl,--max-memory=131072 -Wl,
 # -g -fdebug-prefix-map=/app/src=/C:/Projects/hash-wasm/src
 
 all : \
+		/app/wasm/adler32.wasm \
 		/app/wasm/argon2.wasm \
 		/app/wasm/bcrypt.wasm \
 		/app/wasm/blake2b.wasm \

--- a/src/adler32.c
+++ b/src/adler32.c
@@ -1,0 +1,144 @@
+/* 
+  adler32.c -- compute the Adler-32 checksum of a data stream
+  Copyright (C) 1995-2011, 2016 Mark Adler
+    
+    Licensed under the zlib license:
+  
+    Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+  
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+  
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+  
+    1. The origin of this software must not be misrepresented; you must not
+       claim that you wrote the original software. If you use this software
+       in a product, an acknowledgment in the product documentation would be
+       appreciated but is not required.
+    2. Altered source versions must be plainly marked as such, and must not be
+       misrepresented as being the original software.
+    3. This notice may not be removed or altered from any source distribution.
+  
+    Jean-loup Gailly        Mark Adler
+    jloup@gzip.org          madler@alumni.caltech.edu
+  
+  Modified for hash-wasm by Nicholas Sherlock, 2021
+*/
+
+#define WITH_BUFFER
+#include "hash-wasm.h"
+
+#define bswap_32(x) __builtin_bswap32(x)
+
+#define BASE 65521U     /* largest prime smaller than 65536 */
+#define NMAX 5552
+/* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
+
+#define DO1(buf,i)  {adler += (buf)[i]; sum2 += adler;}
+#define DO2(buf,i)  DO1(buf,i); DO1(buf,i+1);
+#define DO4(buf,i)  DO2(buf,i); DO2(buf,i+2);
+#define DO8(buf,i)  DO4(buf,i); DO4(buf,i+4);
+#define DO16(buf)   DO8(buf,0); DO8(buf,8);
+
+#define MOD(a) a %= BASE
+#define MOD28(a) a %= BASE
+#define MOD63(a) a %= BASE
+
+uint32_t previousAdler = 1;
+
+WASM_EXPORT
+void Hash_Init() {
+  previousAdler = 1;
+}
+
+static uint32_t adler32(uint32_t adler, const uint8_t *buf, uint32_t len) {
+  uint32_t sum2;
+  uint32_t n;
+
+  /* split Adler-32 into component sums */
+  sum2 = (adler >> 16) & 0xffff;
+  adler &= 0xffff;
+
+  /* in case user likes doing a byte at a time, keep it fast */
+  if (len == 1) {
+    adler += buf[0];
+    if (adler >= BASE)
+      adler -= BASE;
+    sum2 += adler;
+    if (sum2 >= BASE)
+      sum2 -= BASE;
+    return adler | (sum2 << 16);
+  }
+
+  /* in case short lengths are provided, keep it somewhat fast */
+  if (len < 16) {
+    while (len--) {
+      adler += *buf++;
+      sum2 += adler;
+    }
+    if (adler >= BASE)
+      adler -= BASE;
+    MOD28(sum2);            /* only added so many BASE's */
+    return adler | (sum2 << 16);
+  }
+
+  /* do length NMAX blocks -- requires just one modulo operation */
+  while (len >= NMAX) {
+    len -= NMAX;
+    n = NMAX / 16;          /* NMAX is divisible by 16 */
+    do {
+      DO16(buf);          /* 16 sums unrolled */
+      buf += 16;
+    } while (--n);
+    MOD(adler);
+    MOD(sum2);
+  }
+
+  /* do remaining bytes (less than NMAX, still just one modulo) */
+  if (len) {                  /* avoid modulos if none remaining */
+    while (len >= 16) {
+      len -= 16;
+      DO16(buf);
+      buf += 16;
+    }
+    while (len--) {
+      adler += *buf++;
+      sum2 += adler;
+    }
+    MOD(adler);
+    MOD(sum2);
+  }
+
+  /* return recombined sums */
+  return adler | (sum2 << 16);
+}
+
+WASM_EXPORT
+void Hash_Update(uint32_t len) {
+  const uint8_t *buf = main_buffer;
+
+  previousAdler = adler32(previousAdler, buf, len);
+}
+
+WASM_EXPORT
+void Hash_Final() {
+  ((uint32_t*)main_buffer)[0] = bswap_32(previousAdler);
+}
+
+WASM_EXPORT
+const uint32_t STATE_SIZE = sizeof(previousAdler); 
+
+WASM_EXPORT
+uint8_t* Hash_GetState() {
+  return (uint8_t*) &previousAdler;
+}
+
+WASM_EXPORT
+void Hash_Calculate(uint32_t length) {
+  Hash_Init();
+  Hash_Update(length);
+  Hash_Final();
+}

--- a/test/adler32.test.ts
+++ b/test/adler32.test.ts
@@ -1,0 +1,115 @@
+import fs from 'fs';
+import { adler32, createAdler32 } from '../lib';
+import { getVariableLengthChunks } from './util';
+/* global test, expect */
+
+test('simple strings', async () => {
+  expect(await adler32('')).toBe('00000001');
+  expect(await adler32('a')).toBe('00620062');
+  expect(await adler32('1234567890')).toBe('0b2c020e');
+  expect(await adler32('a\x00')).toBe('00c40062');
+  expect(await adler32('abc')).toBe('024d0127');
+  expect(await adler32('message digest')).toBe('29750586');
+  expect(await adler32('abcdefghijklmnopqrstuvwxyz')).toBe('90860b20');
+  expect(await adler32('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')).toBe('8adb150c');
+  expect(await adler32('12345678901234567890123456789012345678901234567890123456789012345678901234567890')).toBe('97b61069');
+});
+
+test('unicode strings', async () => {
+  expect(await adler32('😊')).toBe('075b02b2');
+  expect(await adler32('😊a😊')).toBe('1e1105c4');
+  const file = fs.readFileSync('./test/utf8.txt');
+  expect(await adler32(file)).toBe('dd7a5843');
+  expect(await adler32(file.toString())).toBe('dd7a5843');
+});
+
+test('Node.js buffers', async () => {
+  expect(await adler32(Buffer.from([]))).toBe('00000001');
+  expect(await adler32(Buffer.from(['a'.charCodeAt(0)]))).toBe('00620062');
+  expect(await adler32(Buffer.from([0]))).toBe('00010001');
+  expect(await adler32(Buffer.from([0, 1, 0, 0, 2, 0]))).toBe('000f0004');
+});
+
+test('typed arrays', async () => {
+  const arr = [0, 1, 2, 3, 4, 5, 255, 254];
+  expect(await adler32(Buffer.from(arr))).toBe('0345020d');
+  const uint8 = new Uint8Array(arr);
+  expect(await adler32(uint8)).toBe('0345020d');
+  expect(await adler32(new Uint16Array(uint8.buffer))).toBe('0345020d');
+  expect(await adler32(new Uint32Array(uint8.buffer))).toBe('0345020d');
+});
+
+test('long strings', async () => {
+  const SIZE = 5 * 1024 * 1024;
+  const chunk = '012345678\x09';
+  const str = (new Array(Math.floor(SIZE / chunk.length)).fill(chunk)).join('');
+  expect(await adler32(str)).toBe('de04df99');
+});
+
+test('long buffers', async () => {
+  const SIZE = 5 * 1024 * 1024;
+  const buf = Buffer.alloc(SIZE);
+  buf.fill('\x00\x01\x02\x03\x04\x05\x06\x07\x08\xFF');
+  expect(await adler32(buf)).toBe('1b87ca64');
+});
+
+test('chunked', async () => {
+  const hash = await createAdler32();
+  expect(hash.digest()).toBe('00000001');
+  hash.init();
+  hash.update('a');
+  hash.update(new Uint8Array([0]));
+  hash.update('bc');
+  hash.update(new Uint8Array([255, 254]));
+  expect(hash.digest()).toBe('07f90324');
+
+  hash.init();
+  for (let i = 0; i < 1000; i++) {
+    // eslint-disable-next-line no-bitwise
+    hash.update(new Uint8Array([i & 0xFF]));
+  }
+  hash.update(Buffer.alloc(1000).fill(0xDF));
+  expect(hash.digest()).toBe('06904e90');
+});
+
+test('chunked increasing length', async () => {
+  const hash = await createAdler32();
+  const test = async (maxLen: number) => {
+    const chunks = getVariableLengthChunks(maxLen);
+    const flatchunks = chunks.reduce((acc, val) => acc.concat(val), []);
+    const hashRef = await adler32(new Uint8Array(flatchunks));
+    hash.init();
+    chunks.forEach((chunk) => hash.update(new Uint8Array(chunk)));
+    expect(hash.digest('hex')).toBe(hashRef);
+  };
+  const maxLens = [1, 3, 27, 50, 57, 64, 91, 127, 256, 300];
+  await Promise.all(maxLens.map((length) => test(length)));
+});
+
+test('interlaced shorthand', async () => {
+  const [hashA, hashB] = await Promise.all([
+    adler32('a'),
+    adler32('abc'),
+  ]);
+  expect(hashA).toBe('00620062');
+  expect(hashB).toBe('024d0127');
+});
+
+test('interlaced create', async () => {
+  const hashA = await createAdler32();
+  hashA.update('a');
+  const hashB = await createAdler32();
+  hashB.update('abc');
+  expect(hashA.digest()).toBe('00620062');
+  expect(hashB.digest()).toBe('024d0127');
+});
+
+test('Invalid inputs throw', async () => {
+  const invalidInputs = [0, 1, Number(1), {}, [], null, undefined];
+  const hash = await createAdler32();
+
+  invalidInputs.forEach(async (input: any) => {
+    await expect(adler32(input)).rejects.toThrow();
+    expect(() => hash.update(input)).toThrow();
+  });
+});

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -22,7 +22,7 @@ async function createAllFunctions(includeHMAC) : Promise<IHasher[]> {
 
 test('IHasherApi', async () => {
   const functions: IHasher[] = await createAllFunctions(true);
-  expect(functions.length).toBe(19);
+  expect(functions.length).toBe(20);
 
   // eslint-disable-next-line no-restricted-syntax
   for (const fn of functions) {
@@ -67,7 +67,7 @@ test('saveAndLoad', async () => {
 
   const functions: IHasher[] = await createAllFunctions(false);
 
-  expect(functions.length).toBe(18);
+  expect(functions.length).toBe(19);
 
   functions.forEach((fn, index) => {
     fn.init();
@@ -94,7 +94,7 @@ test('saveAndLoad - load as init', async () => {
     fn.update('Hello world');
     return fn.digest();
   });
-  expect(helloWorldHashes.length).toBe(18);
+  expect(helloWorldHashes.length).toBe(19);
   const savedHasherStates = (await createAllFunctions(false)).map((fn) => {
     fn.update('Hello ');
     return fn.save();

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 /* global test, expect */
 import {
-  blake2b, blake3, crc32, md4, md5, sha1, sha256, sha384, sha3,
+  adler32, blake2b, blake3, crc32, md4, md5, sha1, sha256, sha384, sha3,
   xxhash32, xxhash64, createMD4, keccak, ripemd160,
 } from '../lib';
 import { hexStringEqualsUInt8 } from '../lib/util';
@@ -9,6 +9,7 @@ import { MAX_HEAP } from '../lib/WASMInterface';
 
 test('Sync cycle multiple algorithms', async () => {
   for (let i = 0; i < 100; i++) {
+    expect(await adler32('a')).toBe('00620062');
     expect(await blake2b('a')).toBe('333fcb4ee1aa7c115355ec66ceac917c8bfd815bf7587d325aec1864edd24e34d5abe2c6b1b5ee3face62fed78dbef802f2a85cb91d455a8f5249d330853cb3c');
     expect(await blake3('a')).toBe('17762fddd969a453925d65717ac3eea21320b66b54342fde15128d6caf21215f');
     expect(await crc32('a')).toBe('e8b7be43');

--- a/test/throw.test.ts
+++ b/test/throw.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable no-await-in-loop */
 /* global test, expect */
 import {
-  md4, md5, crc32, sha1, sha224, sha256, sha384, sha512, sha3, xxhash32, xxhash64, keccak,
+  adler32, md4, md5, crc32, sha1, sha224, sha256, sha384, sha512, sha3, xxhash32, xxhash64, keccak,
 } from '../lib';
 
 test('Invalid inputs throw after', async () => {
+  await expect(adler32(0 as any)).rejects.toThrow();
   await expect(md4(0 as any)).rejects.toThrow();
   await expect(md5(0 as any)).rejects.toThrow();
   await expect(crc32(0 as any)).rejects.toThrow();


### PR DESCRIPTION
Adler-32 is used as a checksum in the rsync protocol and in zlib compression. The algorithm is taken straight from zlib, which has a compatible license (source distributions need to retain the copyright statement, binary distributions don't require any attribution).

The hash-wasm version crushes the performance of the [popular NPM package adler-32](https://www.npmjs.com/package/adler-32):

![Screen Shot 2021-06-05 at 2 21 42 PM](https://user-images.githubusercontent.com/1921411/120877546-42a54780-c60b-11eb-8415-a5513a85341c.png)