### PR TITLE
Optional IHasher.calculate and Keccak implementation

### DIFF
--- a/lib/keccak.ts
+++ b/lib/keccak.ts
@@ -64,6 +64,9 @@ export function createKeccak(bits: IValidBits = 512): Promise<IHasher> {
       init: () => { wasm.init(bits); return obj; },
       update: (data) => { wasm.update(data); return obj; },
       digest: (outputType) => wasm.digest(outputType, 0x01) as any,
+      calculate: (outputType) => (outputType === 'binary'
+        ? (data) => wasm.calculateBin(data, bits, 0x01)
+        : (data) => wasm.calculateHex(data, bits, 0x01)) as any,
       save: () => wasm.save(),
       load: (data) => { wasm.load(data); return obj; },
       blockSize: 200 - 2 * outputSize,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hash-wasm",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hash-wasm",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hash-wasm",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Lightning fast hash functions for browsers and Node.js using hand-tuned WebAssembly binaries (MD4, MD5, SHA-1, SHA-2, SHA-3, Keccak, BLAKE2, BLAKE3, PBKDF2, Argon2, bcrypt, scrypt, Adler-32, CRC32, CRC32C, RIPEMD-160, HMAC, xxHash, SM3, Whirlpool)",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
The `Hash_Calculate` WASM function seems to be faster, because of less of an overhead due to fewer context switches. Hence, I've exposed it as the `IHasher.calculate` function:

```ts
export type IHasher = {
  /**
   * Shorthand for init . update . digest('binary'|'hex')
   */
  calculate?: {
    (outputType: 'binary'): (data: IDataType) => Uint8Array;
    (outputType?: 'hex'): (data: IDataType) => string;
  }
}
```

It's _optional_, since I was too lazy to implement it for all hashing functions, except for `keccak`. Further, it returns based on the `outputType` the actual hasher function to avoid an if-switch on the "hot" path during frequent hashing. For example:

```ts
const keccak_hasher = await createKeccak(256);
let keccak: (array: Uint8Array) => Uint8Array;
keccak = keccak_hasher.calculate('binary');
```
