### PR TITLE
export ESM code

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "hash-wasm",
   "version": "4.12.0",
   "description": "Lightning fast hash functions for browsers and Node.js using hand-tuned WebAssembly binaries (MD4, MD5, SHA-1, SHA-2, SHA-3, Keccak, BLAKE2, BLAKE3, PBKDF2, Argon2, bcrypt, scrypt, Adler-32, CRC32, CRC32C, RIPEMD-160, HMAC, xxHash, SM3, Whirlpool)",
-  "main": "dist/index.umd.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/lib/index.d.ts",
   "scripts": {
     "build": "sh -c ./scripts/build.sh",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "require": "dist/index.cjs",
     "default": "dist/index.mjs"
   },
-  "types": "dist/lib/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "sh -c ./scripts/build.sh",
     "lint": "npx @biomejs/biome check lib test",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "hash-wasm",
   "version": "4.12.0",
   "description": "Lightning fast hash functions for browsers and Node.js using hand-tuned WebAssembly binaries (MD4, MD5, SHA-1, SHA-2, SHA-3, Keccak, BLAKE2, BLAKE3, PBKDF2, Argon2, bcrypt, scrypt, Adler-32, CRC32, CRC32C, RIPEMD-160, HMAC, xxHash, SM3, Whirlpool)",
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "exports": {
+    "require": "dist/index.cjs",
+    "default": "dist/index.mjs"
+  },
   "types": "dist/lib/index.d.ts",
   "scripts": {
     "build": "sh -c ./scripts/build.sh",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hash-wasm",
   "version": "4.12.0",
   "description": "Lightning fast hash functions for browsers and Node.js using hand-tuned WebAssembly binaries (MD4, MD5, SHA-1, SHA-2, SHA-3, Keccak, BLAKE2, BLAKE3, PBKDF2, Argon2, bcrypt, scrypt, Adler-32, CRC32, CRC32C, RIPEMD-160, HMAC, xxHash, SM3, Whirlpool)",
+  "main": "dist/index.cjs",
   "exports": {
     "require": "dist/index.cjs",
     "default": "dist/index.mjs"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -58,8 +58,11 @@ const MAIN_BUNDLE_CONFIG = {
       format: "umd",
     },
     {
-      file: "dist/index.mjs",
       format: "es",
+      entryFileNames: "[name].mjs",
+      preserveModules: true,
+      preserveModulesRoot: "lib",
+      dir: "dist",
     },
   ],
   plugins: [json(), typescript(), license(LICENSE_CONFIG)],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -53,12 +53,12 @@ const MAIN_BUNDLE_CONFIG = {
   input: "lib/index.ts",
   output: [
     {
-      file: "dist/index.umd.js",
+      file: "dist/index.cjs",
       name: "hashwasm",
       format: "umd",
     },
     {
-      file: "dist/index.esm.js",
+      file: "dist/index.mjs",
       format: "es",
     },
   ],
@@ -69,12 +69,12 @@ const MINIFIED_MAIN_BUNDLE_CONFIG = {
   input: "lib/index.ts",
   output: [
     {
-      file: "dist/index.umd.min.js",
+      file: "dist/index.min.cjs",
       name: "hashwasm",
       format: "umd",
     },
     {
-      file: "dist/index.esm.min.js",
+      file: "dist/index.min.mjs",
       format: "es",
     },
   ],
@@ -90,7 +90,7 @@ const INDIVIDUAL_BUNDLE_CONFIG = (algorithm) => ({
   input: `lib/${algorithm}.ts`,
   output: [
     {
-      file: `dist/${algorithm}.umd.min.js`,
+      file: `dist/${algorithm}.min.cjs`,
       name: "hashwasm",
       format: "umd",
       extend: true,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,6 +32,6 @@ docker volume rm hash-wasm-volume
 # node scripts/optimize
 node scripts/make_json
 node --max-old-space-size=4096 ./node_modules/rollup/dist/bin/rollup -c
-npx tsc ./lib/index --outDir ./dist --downlevelIteration --emitDeclarationOnly --declaration --resolveJsonModule --allowSyntheticDefaultImports
+npx tsc ./lib/index --rootDir ./lib --outDir ./dist --downlevelIteration --emitDeclarationOnly --declaration --resolveJsonModule --allowSyntheticDefaultImports
 
 #-s ASSERTIONS=1 \

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES6",
     "module": "ES6",
-    "lib": ["es2017", "es7", "es6", "dom"],
+    "target": "es2017",
+    "lib": ["es2017", "dom"],
     "baseUrl": ".",
     "rootDir": "lib",
     "strict": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ES6",
     "lib": ["es2017", "es7", "es6", "dom"],
     "baseUrl": ".",
+    "rootDir": "lib",
     "strict": false,
     "esModuleInterop": true,
     "downlevelIteration": true,


### PR DESCRIPTION
`"module"` is a non-standard field that Node.js doesn't read. It uses `"exports"`.

ESM code also needs the `.mjs` file extension.

https://nodejs.org/api/packages.html#determining-module-system