### PR TITLE
finish webpack removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "build": "sh -c ./scripts/build.sh",
     "lint": "npx @biomejs/biome check lib test",
     "prepublishOnly": "sh -c ./scripts/build.sh",
-    "test": "node --expose-gc ./node_modules/.bin/jest --coverage --logHeapUsage",
-    "webpack": "node webpack/webpack.js"
+    "test": "node --expose-gc ./node_modules/.bin/jest --coverage --logHeapUsage"
   },
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
This was only used for a span of about 1 month in 2020.

https://github.com/Daninet/hash-wasm/commits/v4.4.0/webpack/

Missed in 54f568aa04e9aba9e66374de306aa352ea4b0fee